### PR TITLE
REVIEW: add optional Require-Bundle dependency to plugin-api

### DIFF
--- a/maven-plugin/src/main/java/org/sonatype/nexus/pluginbundle/maven/OSGiUtils.java
+++ b/maven-plugin/src/main/java/org/sonatype/nexus/pluginbundle/maven/OSGiUtils.java
@@ -148,7 +148,7 @@ public class OSGiUtils
    * Generates a Require-Bundle header for the Nexus plugin.
    */
   private static String getRequiredBundles(final PluginMetadata metadata) {
-    StringBuilder buf = new StringBuilder();
+    StringBuilder buf = new StringBuilder("org.sonatype.nexus.plugin-api;resolution:=optional");
     for (PluginDependency d : metadata.getPluginDependencies()) {
       if (buf.length() > 0) {
         buf.append(',');


### PR DESCRIPTION
Required for upcoming change on master making the nexus-plugin-api a proper OSGi bundle, which in turn will be used to help migrate other modules to bundles. Marked as optional to avoid breaking the 2.8 branch which doesn't have the nexus-plugin-api as a separate bundle.
